### PR TITLE
add unit support to axes data

### DIFF
--- a/osh5vis.py
+++ b/osh5vis.py
@@ -37,9 +37,9 @@ def osplot(h5data, **kwpassthrough):
 
 
 def new_fig(h5data, figsize=None, dpi=None, facecolor=None, edgecolor=None, linewidth=0.0, frameon=None,
-               tight_layout=None, constrained_layout=None, **kwpassthrough):
+               tight_layout=None, **kwpassthrough):
     plt.figure(figsize=figsize, dpi=dpi, facecolor=facecolor, edgecolor=edgecolor, linewidth=linewidth, frameon=frameon,
-               tight_layout=tight_layout, constrained_layout=constrained_layout)
+               tight_layout=tight_layout)
     osplot(h5data, **kwpassthrough)
     plt.show()
 


### PR DESCRIPTION
 I added the OSUnit object in the DataAxis so that we can do unit conversion. Right now unit conversion does not change the underlying axis data. It is mostly useful for plotting. 

Only a small set of conversion is supported at the moment. The reason is that much more work is required for a full-fledged unit conversion system. The notion of equivalent has to be introduced. Sometimes we might want different unit for same kind of quantity in HEDP. Time for example, pico-second is used for simulation time and micron per second is used for velocity. If we have a physical time unit we also need to take care of the fourier transform counter part (THz is better than $ps^{-1}$). We also need to decide what to do when the operands when their axes are in different unit system (but referring to the same thing).