### PR TITLE
Various enhencements

### DIFF
--- a/osh5utils.py
+++ b/osh5utils.py
@@ -169,8 +169,11 @@ def combine(dir_or_filelist, prefix=None, file_slice=slice(None,), preprocess=No
     :return: combined grid data, one dimension more than the preprocessed original data
     Usage of preprocess:
     The functino list should look like:
-    [func, arg1, arg2, ..., argn, {'kwarg1': val1, 'kwarg2': val2, ..., 'kwargn', valn}] where any of the *args and/or
-    **args can be omitted. see also __parse_func_param for limitations.
+    [(func1, arg11, arg21, ..., argn1, {'kwarg11': val11, 'kwarg21': val21, ..., 'kwargn1', valn1}),
+     (func2, arg12, arg22, ..., argn2, {'kwarg12': val12, 'kwarg22': val22, ..., 'kwargn2', valn2}),
+     ...,
+     (func2, arg1n, arg2n, ..., argnn, {'kwarg1n': val1n, 'kwarg2n': val2n, ..., 'kwargnn', valnn})] where 
+     any of the *args and/or **args can be omitted. see also __parse_func_param for limitations.
         if preprocess=[(numpy.power, 2), (numpy.average, {axis=0}), numpy.sqrt], then the data to be stacked is
         numpy.sqrt( numpy.average( numpy.power( read_h5(file_name), 2 ), axis=0 ) )
     """
@@ -188,7 +191,7 @@ def combine(dir_or_filelist, prefix=None, file_slice=slice(None,), preprocess=No
     res = stack(tmp, axesdata=axesdata)
     if save:
         if not isinstance(save, str):
-            save = dir_or_filelist + res.name + '.h5'
+            save = dir_or_filelist if isinstance(dir_or_filelist, str) else './' + res.name + '.h5'
         osh5io.write_h5(res, save)
     return res
 
@@ -221,7 +224,7 @@ def __parse_func_param(item):
 # #----------------------------------- FFT Wrappers ----------------------------------------
 # sfunc: for shifting; ffunc: for calculating frequency; ftfunc: for fft the data; uafunc: for updating axes
 #
-def __idle(a, *args, **kwargs):
+def __idle(a, *_args, **_kwargs):
     return a
 
 
@@ -255,7 +258,7 @@ def _update_fft_axes(axes, idx, shape, sfunc, ffunc):
 
 
 @__try_update_axes
-def _update_ifft_axes(axes, idx,  shape, sfunc, ffunc):
+def _update_ifft_axes(axes, idx,  shape, _sfunc, ffunc):
     key, en = ['LONG_NAME'], [2]
     warned = False
     for i in idx:
@@ -360,17 +363,17 @@ def __restore_space_shape(xdfunc):
 
 
 @__restore_space_shape
-def __rss_1d(a, s, axes):
+def __rss_1d(a, _s, axes):
     return a.data_attrs['oshape'][-1] if axes is None else a.data_attrs['oshape'][axes]
 
 
 @__restore_space_shape
-def __rss_2d(a, s, axes):
+def __rss_2d(a, _s, axes):
     return a.data_attrs['oshape'][-2:] if axes is None else tuple([a.data_attrs['oshape'][i] for i in axes])
 
 
 @__restore_space_shape
-def __rss_nd(a, s, axes):
+def __rss_nd(a, _s, axes):
     return a.data_attrs['oshape'] if axes is None else tuple([a.data_attrs['oshape'][i] for i in axes])
 
 

--- a/osh5vis.py
+++ b/osh5vis.py
@@ -69,8 +69,8 @@ def osloglog(h5data, **kwpassthrough):
     return __osplot1d(plt.loglog, h5data, **kwpassthrough)
 
 
-def __osplot2d(func, h5data, xlabel=None, ylabel=None, title=None, xlim=None, ylim=None, clim=None, colorbar=True,
-               **kwpassthrough):
+def __osplot2d(func, h5data, xlabel=None, ylabel=None, cblabel=None, title=None, xlim=None, ylim=None, clim=None,
+               colorbar=True, **kwpassthrough):
     extent_stuff = [h5data.axes[1].min, h5data.axes[1].max,
                     h5data.axes[0].min, h5data.axes[0].max]
     plot_object = func(h5data.view(np.ndarray), extent=extent_stuff, aspect='auto', origin='lower', **kwpassthrough)
@@ -91,7 +91,10 @@ def __osplot2d(func, h5data, xlabel=None, ylabel=None, title=None, xlim=None, yl
         plt.clim(clim)
     if colorbar:
         cb = plt.colorbar(plot_object)
-        cb.set_label(h5data.data_attrs['UNITS'].tex())
+        if cblabel is None:
+            cb.set_label(h5data.data_attrs['UNITS'].tex())
+        else:
+            cb.set_label(cblabel)
     return plot_object
 
 

--- a/osh5vis.py
+++ b/osh5vis.py
@@ -34,39 +34,48 @@ def osplot(h5data, **kwpassthrough):
     return plot_object
 
 
-def __osplot1d(func, h5data, xlabel=None, ylabel=None, xlim=None, ylim=None, title=None, **kwpassthrough):
+def __osplot1d(func, h5data, xlabel=None, ylabel=None, xlim=None, ylim=None, title=None, ax=None, **kwpassthrough):
     plot_object = func(h5data.axes[0].ax, h5data.view(np.ndarray), **kwpassthrough)
+    if ax is not None:
+        set_xlim, set_ylim, set_xlabel, set_ylabel, set_title = \
+            ax.set_xlim, ax.set_ylim, ax.set_xlabel, ax.set_ylabel, ax.set_title
+    else:
+        set_xlim, set_ylim, set_xlabel, set_ylabel, set_title = \
+            plt.xlim, plt.ylim, plt.xlabel, plt.ylabel, plt.title
     if xlabel is None:
         xlabel = axis_format(h5data.axes[0].attrs['LONG_NAME'], h5data.axes[0].attrs['UNITS'])
     if ylabel is None:
         ylabel = axis_format(h5data.data_attrs['LONG_NAME'], str(h5data.data_attrs['UNITS']))
     if xlim is not None:
-        plt.xlim(xlim)
+        set_xlim(xlim)
     if ylim is not None:
-        plt.ylim(ylim)
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
+        set_ylim(ylim)
+    set_xlabel(xlabel)
+    set_ylabel(ylabel)
     if title is None:
         title = default_title(h5data)
-        
-    plt.title(title)
+    set_title(title)
     return plot_object
 
 
-def osplot1d(h5data, **kwpassthrough):
-    return __osplot1d(plt.plot, h5data, **kwpassthrough)
+def osplot1d(h5data, ax=None, **kwpassthrough):
+    plot = plt.plot if ax is None else ax.plot
+    return __osplot1d(plot, h5data, **kwpassthrough)
 
 
-def ossemilogx(h5data, **kwpassthrough):
-    return __osplot1d(plt.semilogx, h5data, **kwpassthrough)
+def ossemilogx(h5data, ax=None, **kwpassthrough):
+    semilogx = plt.semilogx if ax is None else ax.semilogx
+    return __osplot1d(semilogx, h5data, **kwpassthrough)
 
 
-def ossemilogy(h5data, **kwpassthrough):
-    return __osplot1d(plt.semilogy, h5data, **kwpassthrough)
+def ossemilogy(h5data, ax=None, **kwpassthrough):
+    semilogy = plt.semilogy if ax is None else ax.semilogy
+    return __osplot1d(semilogy, h5data, **kwpassthrough)
 
 
-def osloglog(h5data, **kwpassthrough):
-    return __osplot1d(plt.loglog, h5data, **kwpassthrough)
+def osloglog(h5data, ax=None, **kwpassthrough):
+    loglog = plt.loglog if ax is None else ax.loglog
+    return __osplot1d(loglog, h5data, **kwpassthrough)
 
 
 def __osplot2d(func, h5data, xlabel=None, ylabel=None, cblabel=None, title=None, xlim=None, ylim=None, clim=None,

--- a/osh5visipy.py
+++ b/osh5visipy.py
@@ -148,7 +148,6 @@ class Generic2DPlotCtrl(object):
         self.xlabel.observe(self.update_xlabel, 'value')
         self.ylabel.observe(self.update_ylabel, 'value')
         self.cbar.observe(self.update_cbar, 'value')
-        self.cbar.observe(self.update_cbar, 'value')
         self.y_max_wgt.observe(self.__update_y_max, 'value')
         self.y_min_wgt.observe(self.__update_y_min, 'value')
         self.x_max_wgt.observe(self.__update_x_max, 'value')
@@ -195,7 +194,6 @@ class Generic2DPlotCtrl(object):
         bnd = [(self.y_min_wgt.value, self.y_max_wgt.value, self.y_step_wgt.value),
                (self.x_min_wgt.value, self.x_max_wgt.value, self.x_step_wgt.value)]
         self._slcs = tuple(slice(*self._data.get_index_slice(self._data.axes[i], bd)) for i, bd in enumerate(bnd))
-        print(self._slcs)
         self.im.figure.clf()
         self.im = self.plot_data()
         # dirty hack
@@ -213,7 +211,9 @@ class Generic2DPlotCtrl(object):
 
     def plot_data(self, **passthrough):
         return osh5vis.osimshow(self.__pp(self._data[self._slcs]), cmap=self.cmap_selector.value,
-                                norm=self.norm_selector.value[0](**self.__get_norm()), **passthrough)
+                                norm=self.norm_selector.value[0](**self.__get_norm()), title=self.title.value,
+                                xlabel=self.xlabel.value, ylabel=self.ylabel.value, cblabel=self.cbar.value,
+                                **passthrough)
 
     def __get_tab0(self):
         return widgets.HBox([widgets.VBox([self.norm_selector, self.norm_selector.value[1]]), self.norm_btn_wgt])

--- a/osh5visipy.py
+++ b/osh5visipy.py
@@ -13,40 +13,25 @@ from matplotlib.colors import LogNorm, Normalize, PowerNorm, SymLogNorm
 print("Importing osh5visipy. Please use `%matplotlib notebook' in your jupyter/ipython notebook")
 
 
+def osimshow_w(data, *args, newfig=True, **kwargs):
+    if newfig:
+        plt.figure()
+    return Generic2DPlotCtrl(data, *args, **kwargs)
+
+
+def slicer_w(data, *args, newfig=True, **kwargs):
+    if newfig:
+        plt.figure()
+    return Slicer(data, *args, **kwargs)
+
+
 class Generic2DPlotCtrl(object):
-    tab_contents = ['Labels', 'Data', 'Colormaps']
+    tab_contents = ['Data', 'Labels', 'Axes', 'Colormaps']
     eps = 1e-40
 
     def __init__(self, data, slcs=(slice(None, ), ), title=None, norm=None):
         self._data, self._slcs = data, slcs
         # # # -------------------- Tab0 --------------------------
-        # title
-        if not title:
-            title = osh5vis.default_title(data)
-        self.if_reset_title = widgets.Checkbox(value=True, description='Auto')
-        self.title = widgets.Text(value=title, placeholder='data', continuous_update=False,
-                                  description='Title:', disabled=self.if_reset_title.value)
-        # x label
-        self.if_reset_xlabel = widgets.Checkbox(value=True, description='Auto')
-        self.xlabel = widgets.Text(value=osh5vis.axis_format(data.axes[1].long_name, data.axes[1].units), placeholder='x',
-                                   continuous_update=False,
-                                   description='X label:', disabled=self.if_reset_xlabel.value)
-        # y label
-        self.if_reset_ylabel = widgets.Checkbox(value=True, description='Auto')
-        self.ylabel = widgets.Text(value=osh5vis.axis_format(data.axes[0].long_name, data.axes[0].units), placeholder='y',
-                                   continuous_update=False,
-                                   description='Y label:', disabled=self.if_reset_ylabel.value)
-        # colorbar
-        self.if_reset_cbar = widgets.Checkbox(value=True, description='Auto')
-        self.cbar = widgets.Text(value=data.units.tex(), placeholder='a.u.', continuous_update=False,
-                                 description='Colorbar:', disabled=self.if_reset_cbar.value)
-        
-        tab0 = widgets.VBox([widgets.HBox([self.title, self.if_reset_title]),
-                             widgets.HBox([self.xlabel, self.if_reset_xlabel]),
-                             widgets.HBox([self.ylabel, self.if_reset_ylabel]),
-                             widgets.HBox([self.cbar, self.if_reset_cbar])])
-
-        # # # -------------------- Tab1 --------------------------
         items_layout = Layout(flex='1 1 auto', width='auto')
         # normalization
         # general parameters: vmin, vmax, clip
@@ -81,22 +66,71 @@ class Generic2DPlotCtrl(object):
 
         # find out default value for norm_selector
         norm_avail = {'Log': ln_wgt, 'Normalize': n_wgt, 'Power': pn_wgt, 'SymLog': sln_wgt}
-        self.norm_selector = widgets.Dropdown(options=norm_avail, 
+        self.norm_selector = widgets.Dropdown(options=norm_avail,
                                               value=norm_avail.get(norm, n_wgt), description='Normalization')
         # additional care for LorNorm()
         self.__handle_lognorm()
         # re-plot button
         self.norm_btn_wgt = widgets.Button(description='Apply', disabled=False, tooltip='set colormap', icon='refresh')
-        tab1 = self.__get_tab1()
+        tab0 = self.__get_tab0()
+
+        # # # -------------------- Tab1 --------------------------
+        # title
+        if not title:
+            title = osh5vis.default_title(data)
+        self.if_reset_title = widgets.Checkbox(value=True, description='Auto')
+        self.title = widgets.Text(value=title, placeholder='data', continuous_update=False,
+                                  description='Title:', disabled=self.if_reset_title.value)
+        # x label
+        self.if_reset_xlabel = widgets.Checkbox(value=True, description='Auto')
+        self.xlabel = widgets.Text(value=osh5vis.axis_format(data.axes[1].long_name, data.axes[1].units),
+                                   placeholder='x', continuous_update=False,
+                                   description='X label:', disabled=self.if_reset_xlabel.value)
+        # y label
+        self.if_reset_ylabel = widgets.Checkbox(value=True, description='Auto')
+        self.ylabel = widgets.Text(value=osh5vis.axis_format(data.axes[0].long_name, data.axes[0].units),
+                                   placeholder='y', continuous_update=False,
+                                   description='Y label:', disabled=self.if_reset_ylabel.value)
+        # colorbar
+        self.if_reset_cbar = widgets.Checkbox(value=True, description='Auto')
+        self.cbar = widgets.Text(value=data.units.tex(), placeholder='a.u.', continuous_update=False,
+                                 description='Colorbar:', disabled=self.if_reset_cbar.value)
+
+        tab1 = widgets.VBox([widgets.HBox([self.title, self.if_reset_title]),
+                             widgets.HBox([self.xlabel, self.if_reset_xlabel]),
+                             widgets.HBox([self.ylabel, self.if_reset_ylabel]),
+                             widgets.HBox([self.cbar, self.if_reset_cbar])])
 
         # # # -------------------- Tab2 --------------------------
+        self.setting_instructions = widgets.Label(value="Enter invalid value to reset", layout=items_layout)
+        self.apply_range_btn = widgets.Button(description='Apply', disabled=False, tooltip='set range', icon='refresh')
+        self.axis_lim_wgt = widgets.HBox([self.setting_instructions, self.apply_range_btn])
+        # x axis
+        self.x_min_wgt = widgets.FloatText(value=self._data.axes[1].min, description='xmin', continuous_update=False,
+                                           layout=items_layout)
+        self.x_max_wgt = widgets.FloatText(value=self._data.axes[1].max, description='xmax', continuous_update=False,
+                                           layout=items_layout)
+        self.x_step_wgt = widgets.FloatText(value=self._data.axes[1].increment, continuous_update=False,
+                                            description='$\Delta x$', layout=items_layout)
+        self.xaxis_lim_wgt = widgets.HBox([self.x_min_wgt, self.x_max_wgt, self.x_step_wgt])
+        # y axis
+        self.y_min_wgt = widgets.FloatText(value=self._data.axes[0].min, description='ymin', continuous_update=False,
+                                           layout=items_layout)
+        self.y_max_wgt = widgets.FloatText(value=self._data.axes[0].max, description='ymax', continuous_update=False,
+                                           layout=items_layout)
+        self.y_step_wgt = widgets.FloatText(value=self._data.axes[0].increment, continuous_update=False,
+                                            description='$\Delta y$', layout=items_layout)
+        self.yaxis_lim_wgt = widgets.HBox([self.y_min_wgt, self.y_max_wgt, self.y_step_wgt])
+        tab2 = widgets.VBox([self.axis_lim_wgt, self.xaxis_lim_wgt, self.yaxis_lim_wgt])
+
+        # # # -------------------- Tab3 --------------------------
         self.cmap_selector = widgets.Dropdown(options=sorted(c for c in plt.cm.datad if not c.endswith("_r")),
                                               value='jet', description='Colormap')
-        tab2 = self.cmap_selector
+        tab3 = self.cmap_selector
 
         # construct the tab
         self.tab = widgets.Tab()
-        self.tab.children = [tab0, tab1, tab2]
+        self.tab.children = [tab0, tab1, tab2, tab3]
         [self.tab.set_title(i, tt) for i, tt in enumerate(self.tab_contents)]
         display(self.tab)
 
@@ -114,18 +148,32 @@ class Generic2DPlotCtrl(object):
         self.xlabel.observe(self.update_xlabel, 'value')
         self.ylabel.observe(self.update_ylabel, 'value')
         self.cbar.observe(self.update_cbar, 'value')
+        self.cbar.observe(self.update_cbar, 'value')
+        self.y_max_wgt.observe(self.__update_y_max, 'value')
+        self.y_min_wgt.observe(self.__update_y_min, 'value')
+        self.x_max_wgt.observe(self.__update_x_max, 'value')
+        self.x_min_wgt.observe(self.__update_x_min, 'value')
+        self.x_step_wgt.observe(self.__update_delta_x, 'value')
+        self.y_step_wgt.observe(self.__update_delta_y, 'value')
+        self.apply_range_btn.on_click(self.update_plot_area)
 
         # plotting and then setting normalization colors
         self.im = self.plot_data()
-        self.__set_norm()
+        # self.__set_norm()
 
     def update_data(self, data, slcs):
         self._data, self._slcs = data, slcs
 
+    def reset_plot_area(self):
+        self.y_min_wgt.value, self.y_max_wgt.value, self.y_step_wgt.value = \
+            self._data.axes[0].min, self._data.axes[0].max, self._data.axes[0].increment
+        self.x_min_wgt.value, self.x_max_wgt.value, self.x_step_wgt.value = \
+            self._data.axes[1].min, self._data.axes[1].max, self._data.axes[1].increment
+
     def redraw(self, data):
         """if the size of the data is the same we can just redraw part of figure"""
         self._data = data
-        self.im.set_data(self.__pp(data))
+        self.im.set_data(self.__pp(data[self._slcs]))
         self.im.figure.canvas.draw()
 
     def update_title(self, change):
@@ -143,6 +191,17 @@ class Generic2DPlotCtrl(object):
     def update_cmap(self, change):
         self.im.set_cmap(change['new'])
 
+    def update_plot_area(self, *_):
+        bnd = [(self.y_min_wgt.value, self.y_max_wgt.value, self.y_step_wgt.value),
+               (self.x_min_wgt.value, self.x_max_wgt.value, self.x_step_wgt.value)]
+        self._slcs = tuple(slice(*self._data.get_index_slice(self._data.axes[i], bd)) for i, bd in enumerate(bnd))
+        print(self._slcs)
+        self.im.figure.clf()
+        self.im = self.plot_data()
+        # dirty hack
+        if self.norm_selector.value[0] == LogNorm:
+            self.im.set_norm(LogNorm())
+
     def refresh_tab_wgt(self, update_list):
         """
         the tab.children is a tuple so we have to reconstruct the whole tab widget when 
@@ -153,15 +212,17 @@ class Generic2DPlotCtrl(object):
         self.tab.children = tuple(newtab)
 
     def plot_data(self, **passthrough):
-        return osh5vis.osimshow(self.__pp(self._data[self._slcs]), cmap=self.cmap_selector.value, **passthrough)
+        return osh5vis.osimshow(self.__pp(self._data[self._slcs]), cmap=self.cmap_selector.value,
+                                norm=self.norm_selector.value[0](**self.__get_norm()), **passthrough)
 
-    def __get_tab1(self):
+    def __get_tab0(self):
         return widgets.HBox([widgets.VBox([self.norm_selector, self.norm_selector.value[1]]), self.norm_btn_wgt])
 
-    def __idle(self, data):
+    @staticmethod
+    def __idle(data):
         return data
 
-    def __handle_lognorm(self, change=None):
+    def __handle_lognorm(self):
         if self.norm_selector.value[0] == LogNorm:
             self.__pp = np.abs
             self.vmax_wgt.value = np.max(np.abs(self._data))
@@ -171,12 +232,12 @@ class Generic2DPlotCtrl(object):
             self.__assgin_valid_vmin()
             self.__pp = self.__idle
 
-    def __update_norm_wgt(self, change=None):
+    def __update_norm_wgt(self, _change):
         """update tab1 (second tab) only and prepare _log_data if necessary"""
         tmp = [None] * len(self.tab_contents)
-        tmp[1] = self.__get_tab1()
+        tmp[0] = self.__get_tab0()
         self.refresh_tab_wgt(tmp)
-        self.__handle_lognorm(change)
+        self.__handle_lognorm()
 
     def set_norm(self, *args):
         # with LogNorm we are actually doing log(data), therefore we have to replot the whole thing to get correct cmap
@@ -185,7 +246,7 @@ class Generic2DPlotCtrl(object):
         # update norm
         self.__set_norm(*args)
 
-    def __set_norm(self, *args):
+    def __get_norm(self):
         vmin = None if self.if_vmin_auto.value else self.norm_selector.value[1].children[0].children[0].value
         vmax = None if self.if_vmax_auto.value else self.vmax_wgt.value
         param = {'vmin': vmin, 'vmax': vmax, 'clip': self.if_clip_cm.value}
@@ -194,6 +255,10 @@ class Generic2DPlotCtrl(object):
         if self.norm_selector.value[0] == SymLogNorm:
             param['linthresh'] = self.linthresh.value
             param['linscale'] = self.linscale.value
+        return param
+
+    def __set_norm(self, *_):
+        param = self.__get_norm()
         self.im.set_norm(self.norm_selector.value[0](**param))
 
     def __assgin_valid_vmin(self, v=None):
@@ -201,9 +266,9 @@ class Generic2DPlotCtrl(object):
         if self.norm_selector.value[0] == LogNorm:
             self.vlogmin_wgt.value = self.eps if v is None or v < self.eps else v
         else:
-            self.vmin_wgt = np.min(self._data) if v is None else v
+            self.vmin_wgt.value = np.min(self._data) if v is None else v
 
-    def __update_vmin(self, change):
+    def __update_vmin(self, _change):
         if self.if_vmin_auto.value:
             self.__assgin_valid_vmin()
             self.vmin_wgt.disabled = True
@@ -212,46 +277,68 @@ class Generic2DPlotCtrl(object):
             self.vmin_wgt.disabled = False
             self.vlogmin_wgt.disabled = False
 
-    def __update_vmax(self, change):
+    def __update_vmax(self, _change):
         if self.if_vmax_auto.value:
             self.vmax_wgt.value = np.max(self._data)
             self.vmax_wgt.disabled = True
         else:
             self.vmax_wgt.disabled = False
 
-    def __update_title(self, *args):
+    def __update_title(self, *_):
         if self.if_reset_title.value:
             self.title.value = osh5vis.default_title(self._data)
             self.title.disabled = True
         else:
             self.title.disabled = False
 
-    def __update_xlabel(self, *args):
+    def __update_xlabel(self, *_):
         if self.if_reset_xlabel.value:
             self.xlabel.value = osh5vis.axis_format(self._data.axes[1].long_name, self._data.axes[1].units)
             self.xlabel.disabled = True
         else:
             self.xlabel.disabled = False
 
-    def __update_ylabel(self, *args):
+    def __update_ylabel(self, *_):
         if self.if_reset_ylabel.value:
             self.ylabel.value = osh5vis.axis_format(self._data.axes[0].long_name, self._data.axes[0].units)
             self.ylabel.disabled = True
         else:
             self.ylabel.disabled = False
 
-    def __update_cbar(self, *args):
+    def __update_cbar(self, *_):
         if self.if_reset_cbar.value:
             self.cbar.value = self._data.units.tex()
             self.cbar.disabled = True
         else:
             self.cbar.disabled = False
 
+    def __update_y_max(self, change):
+        self.y_max_wgt.value = change['new'] if self.y_min_wgt.value < change['new'] < self._data.axes[0].max \
+            else self._data.axes[0].max
+
+    def __update_x_max(self, change):
+        self.x_max_wgt.value = change['new'] if self.x_min_wgt.value < change['new'] < self._data.axes[1].max \
+            else self._data.axes[1].max
+
+    def __update_y_min(self, change):
+        self.y_min_wgt.value = change['new'] if self._data.axes[0].min < change['new'] < self.y_max_wgt.value \
+            else self._data.axes[0].min
+
+    def __update_x_min(self, change):
+        self.x_min_wgt.value = change['new'] if self._data.axes[1].min < change['new'] < self.x_max_wgt.value \
+            else self._data.axes[1].min
+
+    def __update_delta_y(self, change):
+        if not (0 < round(change['new'] / self._data.axes[0].increment) <= self._data[self._slcs].shape[0]):
+            self.y_step_wgt.value = self._data.axes[0].increment
+
+    def __update_delta_x(self, change):
+        if not (0 < round(change['new'] / self._data.axes[1].increment) <= self._data[self._slcs].shape[1]):
+            self.x_step_wgt.value = self._data.axes[1].increment
+
 
 class Slicer(Generic2DPlotCtrl):
-    def __init__(self, data, d=0, new_fig=True, **extra_kwargs):
-        if new_fig:
-            plt.figure()
+    def __init__(self, data, d=0, **extra_kwargs):
         self.x, self.comp, self.data = data.shape[d] // 2, d, data
         self.slcs = self.__get_slice(d)
         self.axis_pos = widgets.FloatText(value=data.axes[self.comp][self.x],
@@ -266,18 +353,16 @@ class Slicer(Generic2DPlotCtrl):
 
         super(Slicer, self).__init__(data[self.slcs], slcs=[i for i in self.slcs if not isinstance(i, int)],
                                      **extra_kwargs)
-        display(self.axis_selector)
-        display(self.axis_pos)
-        display(self.index_slider)
+        display(widgets.HBox([self.axis_pos, self.index_slider, self.axis_selector]))
 
     #         interact(self.update_slice, index=self.index_slider);
 
-    def __update_index_slider(self, change):
+    def __update_index_slider(self, _change):
         self.index_slider.value = round((self.axis_pos.value - self.data.axes[self.comp].min)
                                         / self.data.axes[self.comp].increment)
 
     def __axis_descr_format(self):
-        return self.data.axes[self.comp].attrs['NAME'] + '/(' + self.data.axes[self.comp].attrs['UNITS'].tex() + ') = '
+        return osh5vis.axis_format(self.data.axes[self.comp].long_name, self.data.axes[self.comp].units)
 
     def __get_slice(self, c):
         slcs = [slice(None)] * self.data.ndim
@@ -289,13 +374,14 @@ class Slicer(Generic2DPlotCtrl):
         self.__update_axis_descr()
         self.index_slider.max = self.data.shape[self.comp] - 1
         self.update_data(self.data[self.slcs], slcs=[i for i in self.slcs if not isinstance(i, int)])
+        self.reset_plot_area()
         self.im.figure.clf()
         self.im = self.plot_data()
 
-    def __update_axis_value(self, *args):
+    def __update_axis_value(self, *_):
         self.axis_pos.value = str(self.data.axes[self.comp][self.x])
 
-    def __update_axis_descr(self, *args):
+    def __update_axis_descr(self, *_):
         self.axis_pos.description = self.__axis_descr_format()
 
     def update_slice(self, index):
@@ -303,4 +389,3 @@ class Slicer(Generic2DPlotCtrl):
         self.__update_axis_value()
         self.slcs[self.comp] = self.x
         self.redraw(self.data[self.slcs])
-

--- a/osh5visipy.py
+++ b/osh5visipy.py
@@ -247,7 +247,7 @@ class Generic2DPlotCtrl(object):
         bnd = [(self.y_min_wgt.value, self.y_max_wgt.value, self.y_step_wgt.value),
                (self.x_min_wgt.value, self.x_max_wgt.value, self.x_step_wgt.value)]
         self._slcs = tuple(slice(*self._data.get_index_slice(self._data.axes[i], bd)) for i, bd in enumerate(bnd))
-        self.im.figure.cla()
+        self.im.figure.clf()
         self.im = self.plot_data()
         # dirty hack
         if self.norm_selector.value[0] == LogNorm:

--- a/poynting_flux_example.py
+++ b/poynting_flux_example.py
@@ -33,7 +33,7 @@ def calculate_poyning_flux(b2, b3, e2, e3, save2disk=True):
     s1.data_attrs['LONG_NAME'] = 's_1'
 
     # you can slice the data and the axis will follow automatically
-    nx = s1.axes[1].size()
+    nx = s1.axes[1].size
     s1 = s1[..., nx//20: -nx//20-1]
 
     # integrate over x2 (and x3 if it is a 3D sim.), s1 will be 1D now.


### PR DESCRIPTION
Users can now use axes value to index the array in a more intuitive way than using the subrange function (which will be deprecated in the future). Suppose e1 is the field data from a 2D simulation, e1.loc[20.8: 188.0, :] will select the field data on grid points where 20.8<'x2'<188.0. Same selection can be achieved using the isel method: e1.isel(x2=slice(20.8, 188.0)). There is also a new method 'index_of' returning the index number for a given axis name. In previous example e1.index_of('x2') will return 0.

Users can now use axes name in most of the numpy ufuncs and fft routines. For example, fft(e1, axis='x2') and np.average(e1, axis='x2') are valid expressions now.

osh5utils.combine now can do more sophisticated preprocessing before stacking.

More widgets added to the ipywidgets plotting tool.